### PR TITLE
write on enter even if the buffer is not modified

### DIFF
--- a/.vim/functions.vim
+++ b/.vim/functions.vim
@@ -163,19 +163,19 @@ nnoremap <silent> <leader>p :PasteWithPasteMode<CR>
 " Writes the current buffer if it's needed, unless we're the in QuickFix mode.
 " ---------------
 
-function WriteBufferIfNecessary()
-  if &modified && !&readonly
+function WriteBufferIfAble()
+  if !&readonly
     :write
   endif
 endfunction
-command! WriteBufferIfNecessary call WriteBufferIfNecessary()
+command! WriteBufferIfAble call WriteBufferIfAble()
 
 function CRWriteIfNecessary()
   if &filetype == "qf"
     " Execute a normal enter when in Quickfix list.
     execute "normal! \<enter>"
   else
-    WriteBufferIfNecessary
+    WriteBufferIfAble
   endif
 endfunction
 


### PR DESCRIPTION
I found this handy when working with Grunt watchers since you often need to update the timestamp on a file to kickoff a task.
