### PR TITLE
switch.vim definitions for CoffeeScript

### DIFF
--- a/.vim/plugins.vim
+++ b/.vim/plugins.vim
@@ -304,6 +304,10 @@ xmap ia <Plug>SidewaysArgumentTextobjI
 nnoremap - :Switch<cr>
 autocmd FileType coffee let g:switch_custom_definitions =
     \ [
+    \   [' ->', ' =>', ' (done) ->', ' (done) =>'],
+    \ ]
+autocmd BufNewFile,BufRead *[Ss]pec.coffee let g:switch_custom_definitions =
+    \ [
     \   {
     \     '^\(\s\+\)\?describe \(''[^'']\+''\)':  '\1xdescribe \2',
     \     '^\(\s\+\)\?xdescribe \(''[^'']\+''\)':  '\1describe.only \2',


### PR DESCRIPTION
switch.vim definitions for CoffeeScript and specs
- switch between `it`, `xit` and `it.only`
- switch between `describe`, `xdescribe`, and `describe.only`
- switch between `->`, `=>`, `(done) ->`, and `(done) =>`
