### PR TITLE
set popular pastetoggle mapping

### DIFF
--- a/.vim/mappings.vim
+++ b/.vim/mappings.vim
@@ -29,6 +29,8 @@ nnoremap Y y$
 noremap H ^
 noremap L $
 
+set pastetoggle=<F2>
+
 " ---------------
 " Window Movement
 " ---------------


### PR DESCRIPTION
What do you think of adding this mapping? 

It's a quick alternative to `:set paste`/`:set nopaste`. It works in both normal and insert modes.

![Demo](http://g.recordit.co/Nlfi98oxnz.gif)

Taken from here:
http://vim.wikia.com/wiki/Toggle_auto-indenting_for_code_paste